### PR TITLE
RILseq 0.48

### DIFF
--- a/RILseq/__init__.py
+++ b/RILseq/__init__.py
@@ -32,8 +32,7 @@ def flat_list(list_to_flat):
 
 # Functions for simple mapping (single fragment)
 def run_bwa(bwa_cmd, fname1, fname2, output_dir, output_prefix, mismatches,
-            fasta_genome, params_aln, params_sampe, params_samse, samtools_cmd,
-            processors=1):
+            fasta_genome, params_aln, params_sampe, params_samse, samtools_cmd):
     """
     Run bwa on paired or single end fastq files. write a sorted bam and a bai
     file
@@ -49,7 +48,6 @@ def run_bwa(bwa_cmd, fname1, fname2, output_dir, output_prefix, mismatches,
     - `params_sampe`: extra paarmeters for sampe execution
     - `params_samse`: extra parameters for samse execution
     - `samtools_cmd`: samtools command
-    - `processors`: Number of processors to utilize
 
     Return
     - `bamfile`: Output bam file name
@@ -59,7 +57,7 @@ def run_bwa(bwa_cmd, fname1, fname2, output_dir, output_prefix, mismatches,
    
     # Added 11.2.17 - bug fix for adding of the params_aln parameters.
     # This param was ignored when using the splitting option of subprocess.
-    next_cmd = [bwa_cmd, 'aln', '-n', str(mismatches), '-t', str(processors)]
+    next_cmd = [bwa_cmd, 'aln', '-n', str(mismatches)]
     next_cmd.extend(params_aln.split())
     next_cmd.extend([fasta_genome, fname1])
 
@@ -68,7 +66,7 @@ def run_bwa(bwa_cmd, fname1, fname2, output_dir, output_prefix, mismatches,
 
     if fname2:
         sai2 = NamedTemporaryFile(dir=output_dir)
-        next_cmd = [bwa_cmd, 'aln', '-n', str(mismatches), '-t', str(processors)]
+        next_cmd = [bwa_cmd, 'aln', '-n', str(mismatches)]
         next_cmd.extend(params_aln.split())
         next_cmd.extend([fasta_genome, fname2])
         logging.info("Executing %s", ' '.join(next_cmd))
@@ -356,6 +354,8 @@ def read_transcripts(trans_gff, feature='exon', identifier='gene_id'):
     """
     tus = {}
     for line in csv.reader(open(trans_gff), delimiter='\t'):
+        if line[0].startswith('#') or line[0].startswith('@'):
+            continue
         if line[2] != feature:
             continue
         ids_dict = {}

--- a/RILseq/ecocyc_parser.py
+++ b/RILseq/ecocyc_parser.py
@@ -68,7 +68,7 @@ def read_fsas(ec_dir='/home/users/assafp/Database/EcoCyc/current/data'):
     from Bio import SeqIO
     fsa_seqs = {}
     for fsa_name in glob.glob("%s/*-*.fsa"%(ec_dir)):
-        fsa_seqs[fsa_name.rsplit('.',1)[0].split('-',1)[1]] =\
+        fsa_seqs[fsa_name.rsplit('/',1)[1].rsplit('.',1)[0].split('-',1)[1]] =\
                      SeqIO.read(open(fsa_name), 'fasta').seq
     return fsa_seqs
 

--- a/bin/RILseq_significant_regions.py
+++ b/bin/RILseq_significant_regions.py
@@ -59,12 +59,12 @@ def process_command_line(argv):
         ' meaning this is the highest amount of IP reads that can be obtained'
         ' in this library given the amount of total RNA.')
     parser.add_argument(
-        '--ec_dir', #default='/home/users/assafp/Database/EcoCyc/19.0/data',
-        help='EcoCyc data dir, used to map the regions to genes. If not'
+        '--bc_dir', #default='/home/users/assafp/Database/EcoCyc/19.0/data',
+        help='BioCyc data dir, used to map the regions to genes. If not'
         ' given only the regions will be reported')
     parser.add_argument(
         '--ribozero', default=False, action='store_true',
-        help='Remove rRNA from the list of chimeric reads.')
+        help='Remove rRNA prior to the statistical analysis.')
     parser.add_argument(
         '--all_interactions', default=False, action='store_true',
         help='Skip all statistical tests and report all the interactions.')
@@ -145,10 +145,10 @@ def process_command_line(argv):
 
 def main(argv=None):
     settings = process_command_line(argv)
-    if settings.ribozero and settings.ec_dir:
+    if settings.ribozero and settings.bc_dir:
         try:
             uid_pos,_,_,_,_,rRNAs = RILseq.ecocyc_parser.read_genes_data(
-                settings.ec_dir)
+                settings.bc_dir)
         except IOError:
             raise 
         rr_pos = []
@@ -259,7 +259,7 @@ def main(argv=None):
     # Read the additional data to decorate the results with
     RILseq.report_interactions(
         region_interactions, sys.stdout, interacting_regions, settings.seglen,
-        settings.ec_dir, settings.genome, settings.EC_chrlist, settings.refseq_dir,
+        settings.bc_dir, settings.genome, settings.EC_chrlist, settings.refseq_dir,
         settings.targets_file, settings.rep_table, settings.single_counts,
         settings.shuffles, settings.RNAup_cmd, settings.servers,
         settings.length, settings.est_utr_lens, settings.pad_seqs,

--- a/bin/map_chimeric_fragments.py
+++ b/bin/map_chimeric_fragments.py
@@ -103,9 +103,6 @@ def process_command_line(argv):
         'where there is no signal, the poly G might just be noise.'
         ' When using other sequencing technologies set to 1.')
     parser.add_argument(
-        '-p', '--processors', type=int, default=8,
-        help='Number of processors to be used by bwa aln.')
-    parser.add_argument(
         '-f', '--feature', default='exon',
         help='Name of features to count on the GTF file (column 2).')
     parser.add_argument(
@@ -118,7 +115,7 @@ def process_command_line(argv):
         '-S', '--samtools_cmd', default='samtools',
         help='Samtools executable.')
     parser.add_argument(
-        '--params_aln', default='-N -M 0',
+        '--params_aln', default='-t 8 -N -M 0',
         help='Additional parameters for aln function of bwa.')
     parser.add_argument(
         '--samse_params', default='-n 1000',
@@ -173,7 +170,7 @@ def main(argv=None):
                     settings.dirout, bamheadname, settings.max_mismatches,
                     settings.genome_fasta, settings.params_aln,
                     '', settings.samse_params,
-                    settings.samtools_cmd, processors=settings.processors)
+                    settings.samtools_cmd)
             bamin = pysam.Samfile(bamname)
             reads_in.append(RILseq.read_bam_file(
                     bamin, bamin.references, settings.allowed_mismatches))

--- a/bin/map_single_fragments.py
+++ b/bin/map_single_fragments.py
@@ -51,9 +51,6 @@ def process_command_line(argv):
         ' files will be the original ones. Use this when treating libraries'
         " built using Livny's protocol.")
     parser.add_argument(
-        '-p', '--processors', type=int, default=8,
-        help='Number of processors to be used by bwa aln.')
-    parser.add_argument(
         '-f', '--feature', default='exon',
         help='Name of features to count on the GTF file (column 2).')
     parser.add_argument(
@@ -79,7 +76,7 @@ def process_command_line(argv):
         '-S', '--samtools_cmd', default='samtools',
         help='Samtools executable.')
     parser.add_argument(
-        '-a', '--params_aln', default='-k 1 -R 200 -l 20',
+        '-a', '--params_aln', default='-t 32 -R 200',
         help='Additional parameters for aln function of bwa.')
     parser.add_argument(
         '-s', '--sampe_params', default='-a 1500 -P',
@@ -118,8 +115,7 @@ def main(argv=None):
             settings.bwa_exec, r1_name, r2_name,
             settings.dirout, outhead, settings.allowed_mismatches,
             settings.genome_fasta, settings.params_aln, settings.sampe_params,
-            settings.samse_params, settings.samtools_cmd,
-            processors=settings.processors)
+            settings.samse_params, settings.samtools_cmd)
         samfile = pysam.Samfile(bamname)
         if settings.genes_gff:
             lib_order.append(libname)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
     
 setup(name='RILseq',
-      version='0.47',
+      version='0.48',
       description='Processing RILSeq experiments results',
       long_description=readme(),
       classifiers=[


### PR DESCRIPTION
1. Erased processors parameter from the __init__.py script and map_chimeric_fragments.py.
processors (-t) can be added to --bwa_params parameter.
Default values unchanged.
2. Changed the bwa_params in map_single_fragments, and erased the -k 1 -l 20 params (The use of seeding).
3. Bug fix in ecocyc_parser.py when the directory name had '-'. (when reading the .fsa file from the ecocyc_dir)
4. Cosmetic In RILseq_significant_regions.py: change --ec_dir to --bc_dir
5. Bugfix in plot_region_interactions.py:
replaced an "and" with an "or" in one of the conditions and added additional text to the figure.
6. added consideration to '#' or '@' in __init__.py in read_transcripts().
7. Changed documentation in RILseq_significant_regions.py --ribozero to "Remove rRNA prior to the statistical analysis."
8. Added a folder named run_example containing a tar file with results file from runs with stat libraries.